### PR TITLE
feat: Explicitly install chromium on workflow

### DIFF
--- a/.github/workflows/reg.yml
+++ b/.github/workflows/reg.yml
@@ -18,6 +18,8 @@ jobs:
       - name: npm install, build, and test
         run: |
           pnpm i --frozen-lockfile
+      - name: install browser
+        run: pnpx puppeteer browsers install chrome
       - name: run screenshots
         run: pnpm ci:screenshots
       - name: workaround for detached HEAD


### PR DESCRIPTION
regのworkflowで、pnpmのcacheがある場合にchromiumはキャッシュされないがそのまま`screenshots`を実行してしまっていたので明示的にchromiumをインストールするよう修正